### PR TITLE
changed .gitignore and makefile.osx 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 src/*.exe
-src/dogecoin
-src/dogecoind
-src/test_dogecoin
+src/isracoind
+src/test_isracoin
 .*.swp
 *.*~*
 *.bak

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -73,7 +73,7 @@ DEBUGFLAGS = -g
 endif
 
 # osx 10.9 has changed the stdlib default to libc++. To prevent some link error, you may need to use libstdc++
-CFLAGS += -stdlib=libstdc++
+#CFLAGS += -stdlib=libstdc++
 
 # ppc doesn't work because we don't support big-endian
 CFLAGS += -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \


### PR DESCRIPTION
1) .gitignore - changed to isracoin so we won't track binaries 
2) makefile.osx  - commented out a line to prevent Undefined symbols for architecture x86_64
